### PR TITLE
Parsing banner from CNXN response

### DIFF
--- a/webadb.js
+++ b/webadb.js
@@ -135,6 +135,9 @@ var Adb = {};
 					adb.max_payload = response.arg1;
 					if (response.arg0 == VERSION_NO_CHECKSUM)
 						Adb.Opt.use_checksum = false;
+					adb.banner = new TextDecoder("utf-8").decode(response.data);
+					let pieces = adb.banner.split(':');
+					adb.mode = pieces[0];
 					return adb;
 				})
 			);


### PR DESCRIPTION
A banner is somewhat like this:

```
recovery::ro.product.name=meizu_16thPlus_CN;ro.product.model=16th Plus;ro.product.device=16thPlus;features=cmd,stat_v2,shell_v2
```

reference: [system/core/adb/adb.cpp](https://github.com/aosp-mirror/platform_system_core/blob/8bde191/adb/adb.cpp#L236)