### PR TITLE
Adb: Reset device in initialization

### DIFF
--- a/webadb.js
+++ b/webadb.js
@@ -58,6 +58,10 @@
 		this.device.close();
 	};
 
+	Adb.WebUSB.Transport.prototype.reset = function() {
+		this.device.reset();
+	};
+
 	Adb.WebUSB.Transport.prototype.send = function(ep, data) {
 		if (Adb.Opt.dump)
 			hexdump(new DataView(data), "" + ep + "==> ");
@@ -175,6 +179,8 @@
 
 		this.ep_in = get_ep_num(match.alt.endpoints, "in");
 		this.ep_out = get_ep_num(match.alt.endpoints, "out");
+
+		this.transport.reset();
 	}
 
 	Adb.WebUSB.Device.prototype.open = function(service) {


### PR DESCRIPTION
webadb.js fails to connect to my device on Linux:
A transfer error has occurred.

However, with the same configurations, it works on Windows. This
indicates handling of USB devices of host (AMD X570) on Linux
might lead to undesired results. Though, without further testing,
the interference from userspace (Ubuntu 20.04, KDE) can not be
ruled out.

Thus, this patch calls reset() to ensure the USB port is in a
clean state before we send the data.

Signed-off-by: Jesse Chan <jc@linux.com>