### PR TITLE
reset fastboot device during initialization

### DIFF
--- a/webadb.js
+++ b/webadb.js
@@ -229,6 +229,8 @@
 
 		this.ep_in = get_ep_num(match.alt.endpoints, "in");
 		this.ep_out = get_ep_num(match.alt.endpoints, "out");
+
+		this.transport.reset();
 	};
 
 	Fastboot.WebUSB.Device.prototype.send = function(data) {


### PR DESCRIPTION
The change made for adb in 313fe18211841ba1b8ed3ece816b41a2701cb2ba to
reset to a clean state before starting is also needed for fastboot.